### PR TITLE
fix: Only detect named variables, not sections etc

### DIFF
--- a/src/download-repo.ts
+++ b/src/download-repo.ts
@@ -22,7 +22,7 @@ function getMapStream(templateVariables: Set<string>) {
       fileStream.on('end', () => {
         const template: string[] = parse(templateChunks.join(''));
         template
-          .filter((entry) => entry[0] !== 'text')
+          .filter((entry) => entry[0] === 'name')
           .map((entry) => entry[1])
           .forEach((entry) => templateVariables.add(entry));
       });

--- a/src/walk.ts
+++ b/src/walk.ts
@@ -1,5 +1,4 @@
 import { render } from 'mustache';
-// import { readdir, writeFileSync, readFileSync } from 'fs';
 import { promises as fsp } from 'fs';
 import { join } from 'path';
 import { debug } from './log';


### PR DESCRIPTION
Previously the template parsing logic looked for anything that was not
'text'; this patch changes the logic to only look for 'name', so that we
don't attempt to handle mustache constructs like 'sections'.

Also deletes some commented out code that I noticed